### PR TITLE
fix(boards): Fix closing brackets

### DIFF
--- a/app/boards/shields/cradio/cradio.dtsi
+++ b/app/boards/shields/cradio/cradio.dtsi
@@ -26,10 +26,6 @@
 	kscan0: kscan {
 		compatible = "zmk,kscan-gpio-direct";
 		label = "KSCAN";
-	};
-	};	
-		
-	&kscan0 {
 		input-gpios
 		= <&pro_micro_d 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_a 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
@@ -49,4 +45,5 @@
 		, <&pro_micro_d 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_d 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		;
+	};
 };


### PR DESCRIPTION
This moves the `input-gpios` back into the initial `kscan0` definition like before, but with a closing bracket in the right place to separate `default_transform` from `kscan0`.