### PR TITLE
fix(shields): Whitespace and indentation

### DIFF
--- a/app/boards/shields/cradio/Kconfig.defconfig
+++ b/app/boards/shields/cradio/Kconfig.defconfig
@@ -11,15 +11,12 @@ config ZMK_SPLIT_BLE_ROLE_CENTRAL
 
 endif
 
-
 if SHIELD_CRADIO_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "Cradio_Right"
 
 endif
-
-
 
 if SHIELD_CRADIO_RIGHT || SHIELD_CRADIO_LEFT
 

--- a/app/boards/shields/cradio/cradio.dtsi
+++ b/app/boards/shields/cradio/cradio.dtsi
@@ -3,47 +3,50 @@
  *
  * SPDX-License-Identifier: MIT
  */
+
 #include <dt-bindings/zmk/matrix_transform.h>
- 
+
 / {
+
 	chosen {
 		zmk,kscan = &kscan0;
 		zmk,matrix_transform = &default_transform;
 	};
-		
+
 	default_transform: keymap_transform_0 {
-	compatible = "zmk,matrix-transform";
-        columns = <34>;
-        rows = <1>;
+		compatible = "zmk,matrix-transform";
+		columns = <34>;
+		rows = <1>;
 		map = <
-	RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) 		RC(0,21) RC(0,20) RC(0,19) RC(0,18) RC(0,17) 
-	RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) 		RC(0,26) RC(0,25) RC(0,24) RC(0,23) RC(0,22)   
-	RC(0,10)RC(0,11) RC(0,12) RC(0,13) RC(0,14) 		RC(0,31) RC(0,30) RC(0,29) RC(0,28) RC(0,27) 
-	RC(0,15)  RC(0,16) 					RC(0,33) RC(0,32)  
-	>;
-	};	
-	
+		RC(0,0)  RC(0,1)  RC(0,2)  RC(0,3)  RC(0,4)    RC(0,21) RC(0,20) RC(0,19) RC(0,18) RC(0,17)
+		RC(0,5)  RC(0,6)  RC(0,7)  RC(0,8)  RC(0,9)    RC(0,26) RC(0,25) RC(0,24) RC(0,23) RC(0,22)
+		RC(0,10) RC(0,11) RC(0,12) RC(0,13) RC(0,14)   RC(0,31) RC(0,30) RC(0,29) RC(0,28) RC(0,27)
+		                           RC(0,15) RC(0,16)   RC(0,33) RC(0,32)
+		>;
+	};
+
 	kscan0: kscan {
 		compatible = "zmk,kscan-gpio-direct";
 		label = "KSCAN";
 		input-gpios
-		= <&pro_micro_d 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_a 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_a 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_a 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_a 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		= <&pro_micro_d  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_a  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_a  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_a  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_a  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_d 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		, <&pro_micro_d 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_a 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-		, <&pro_micro_d 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_a  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro_d  9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		;
 	};
+
 };

--- a/app/boards/shields/cradio/cradio_left.overlay
+++ b/app/boards/shields/cradio/cradio_left.overlay
@@ -3,4 +3,5 @@
  *
  * SPDX-License-Identifier: MIT
  */
+
 #include "cradio.dtsi"

--- a/app/boards/shields/cradio/cradio_right.overlay
+++ b/app/boards/shields/cradio/cradio_right.overlay
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
+
 #include "cradio.dtsi"
 
 &default_transform {


### PR DESCRIPTION
To help me spot the issue in #34, I fixed some indentation and made use of whitespace more consistent. 

(I daren't touch your keymap file though :stuck_out_tongue:)